### PR TITLE
Fix: Limit article max span

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
 	"svelteSortOrder": "scripts-markup-styles",
 	"semi": true,
-	"printWidth": 120,
+	"printWidth": 100,
 	"singleQuote": true,
 	"tabWidth": 2
 }

--- a/src/Docs.svelte
+++ b/src/Docs.svelte
@@ -16,7 +16,11 @@
 	<article>
 		{#each sections as { slug, title, content, path }}
 			<section>
-				<h2 id={slug} class:anchor on:mouseenter={() => (anchor = true)} on:mouseleave={() => (anchor = false)}>
+				<h2
+					id={slug}
+					class:anchor
+					on:mouseenter={() => (anchor = true)}
+					on:mouseleave={() => (anchor = false)}>
 					<Link href="#{slug}">
 						<Icon name="link" />
 					</Link>
@@ -129,7 +133,7 @@
 
 	@media only screen and (min-width: 769px) {
 		main {
-			grid-template-columns: minmax(12em, 20%) minmax(0, 1fr);
+			grid-template-columns: minmax(12em, 20%) minmax(0, 60em);
 		}
 
 		aside {


### PR DESCRIPTION
- Reduce max value for second column from `1fr` to `60em`
- Reduce prettier print width to 100